### PR TITLE
feat: Evaluate dependencies against all policies

### DIFF
--- a/src/pkg/policy/contributors_ratio.rs
+++ b/src/pkg/policy/contributors_ratio.rs
@@ -64,6 +64,7 @@ impl Policy for ContributorsRatio {
         for (rate, author) in authors_with_rate {
             if rate > self.max_contributor_ratio {
                 return Ok(Evaluation::Fail(
+                    "contributors_ratio".to_string(),
                     dependency.clone(),
                     format!(
                         "the rate of contribution is too high ({} > {}) for author {}",
@@ -72,7 +73,10 @@ impl Policy for ContributorsRatio {
                 ));
             }
         }
-        Ok(Evaluation::Pass(dependency.clone()))
+        Ok(Evaluation::Pass(
+            "contributors_ratio".to_string(),
+            dependency.clone(),
+        ))
     }
 }
 
@@ -164,7 +168,10 @@ mod tests {
         };
         let result = contributors_ratio_policy.evaluate(&dependency);
 
-        result.should(be_ok(equal(Evaluation::Pass(dependency))));
+        result.should(be_ok(equal(Evaluation::Pass(
+            "contributors_ratio".to_string(),
+            dependency,
+        ))));
     }
     #[test]
     fn if_the_contributor_ratio_for_the_latest_release_is_higher_than_90_percent_it_should_fail() {
@@ -222,6 +229,7 @@ mod tests {
         let result = contributors_ratio_policy.evaluate(&dependency);
 
         result.should(be_ok(equal(Evaluation::Fail(
+            "contributors_ratio".to_string(),
             dependency,
             "the rate of contribution is too high (1 > 0.9) for author SomeAuthor".to_owned(),
         ))));

--- a/src/pkg/policy/max_issue_lifespan.rs
+++ b/src/pkg/policy/max_issue_lifespan.rs
@@ -16,9 +16,12 @@ impl Policy for MaxIssueLifespan {
             .get_issue_lifespan(&dependency.repository)?;
 
         if issue_lifespan > self.max_issue_lifespan {
-            Ok(Evaluation::Fail(dependency.clone(), format!("the issue lifespan is {} seconds, which is greater than the maximum allowed lifespan of {} seconds", issue_lifespan, self.max_issue_lifespan)))
+            Ok(Evaluation::Fail("max_issue_lifespan".to_string(),dependency.clone(), format!("the issue lifespan is {} seconds, which is greater than the maximum allowed lifespan of {} seconds", issue_lifespan, self.max_issue_lifespan)))
         } else {
-            Ok(Evaluation::Pass(dependency.clone()))
+            Ok(Evaluation::Pass(
+                "max_issue_lifespan".to_string(),
+                dependency.clone(),
+            ))
         }
     }
 }
@@ -59,9 +62,10 @@ mod tests {
         let issue_lifespan = MaxIssueLifespan::new(retriever, max_allowed_issue_lifespan);
 
         let evaluation = issue_lifespan.evaluate(&dependency());
-        evaluation
-            .unwrap()
-            .should(equal(Evaluation::Pass(dependency())));
+        evaluation.unwrap().should(equal(Evaluation::Pass(
+            "max_issue_lifespan".to_string(),
+            dependency(),
+        )));
     }
 
     #[test]
@@ -79,11 +83,12 @@ mod tests {
 
         let evaluation = issue_lifespan.evaluate(&dependency());
         match evaluation.unwrap() {
-            Evaluation::Fail(dep, reason) => {
+            Evaluation::Fail(policy, dep, reason) => {
+                policy.should(equal("max_issue_lifespan".to_string()));
                 dep.should(equal(dependency()));
                 reason.should(equal("the issue lifespan is 102 seconds, which is greater than the maximum allowed lifespan of 100 seconds"));
             }
-            Evaluation::Pass(_) => {
+            Evaluation::Pass(_, _) => {
                 unreachable!()
             }
         }

--- a/src/pkg/policy/min_number_of_releases_required.rs
+++ b/src/pkg/policy/min_number_of_releases_required.rs
@@ -32,9 +32,13 @@ impl Policy for MinNumberOfReleasesRequired {
             .count();
 
         if num_tags_in_range == self.number_of_releases {
-            Ok(Evaluation::Pass(dependency.clone()))
+            Ok(Evaluation::Pass(
+                "min_number_of_releases_required".to_string(),
+                dependency.clone(),
+            ))
         } else {
             Ok(Evaluation::Fail(
+                "min_number_of_releases_required".to_string(),
                 dependency.clone(),
                 format!(
                     "expected {} releases in the last {} days, but found {}",
@@ -129,7 +133,10 @@ mod tests {
         let result: Result<Evaluation, Box<dyn Error>> =
             number_of_releases_policy.evaluate(&dependency);
 
-        result.should(be_ok(equal(Evaluation::Pass(dependency))));
+        result.should(be_ok(equal(Evaluation::Pass(
+            "min_number_of_releases_required".to_string(),
+            dependency,
+        ))));
     }
 
     #[test]
@@ -169,6 +176,7 @@ mod tests {
             number_of_releases_policy.evaluate(&dependency);
 
         result.should(be_ok(equal(Evaluation::Fail(
+            "min_number_of_releases_required".to_string(),
             dependency,
             "expected 2 releases in the last 1260 days, but found 1".to_string(),
         ))));
@@ -224,6 +232,7 @@ mod tests {
             number_of_releases_policy.evaluate(&dependency);
 
         result.should(be_ok(equal(Evaluation::Fail(
+            "min_number_of_releases_required".to_string(),
             dependency,
             "expected 2 releases in the last 1260 days, but found 0".to_string(),
         ))));

--- a/src/pkg/policy/mod.rs
+++ b/src/pkg/policy/mod.rs
@@ -56,17 +56,17 @@ pub trait Clock: Sync + Send {
 
 #[derive(Clone, Debug)]
 pub enum Evaluation {
-    Pass(Dependency),
-    Fail(Dependency, String),
+    Pass(String, Dependency),
+    Fail(String, Dependency, String),
 }
 
 impl PartialEq for Evaluation {
     fn eq(&self, other: &Self) -> bool {
-        matches!(
-            (self, other),
-            (Evaluation::Pass(_), Evaluation::Pass(_))
-                | (Evaluation::Fail(_, _), Evaluation::Fail(_, _))
-        )
+        match (self, other) {
+            (Evaluation::Fail(policy, _, _), Evaluation::Fail(policy2, _, _))
+            | (Evaluation::Pass(policy, _), Evaluation::Pass(policy2, _)) => policy == policy2,
+            _ => false,
+        }
     }
 }
 


### PR DESCRIPTION
Previously, the dependencies were only evaluated against policies until one of them failed. Now, they are evaluated with all policies, even if the evaluation fails. All results are reported to the CSV.