### PR TITLE
chore: Remove the expects testing dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,15 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,16 +239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dean"
 version = "0.1.0"
 dependencies = [
@@ -266,7 +247,6 @@ dependencies = [
  "concurrent_lru",
  "csv",
  "dirs-next",
- "expects",
  "git2",
  "itertools",
  "lazy_static",
@@ -284,12 +264,6 @@ dependencies = [
  "time",
  "toml",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difflib"
@@ -337,14 +311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "expects"
-version = "0.1.0"
-source = "git+https://github.com/tembleking/expects?branch=master#9925764184e917a512a44e75cf81b10d83f1527d"
-dependencies = [
- "pretty_assertions",
 ]
 
 [[package]]
@@ -945,15 +911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,18 +962,6 @@ checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
-dependencies = [
- "ansi_term",
- "ctor",
- "diff",
- "output_vt100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,3 @@ rusqlite = "0.27.0"
 
 [dev-dependencies]
 mockall = "0.11.0"
-expects = { git = "https://github.com/tembleking/expects", branch = "master" }

--- a/src/infra/git.rs
+++ b/src/infra/git.rs
@@ -222,9 +222,6 @@ impl Repository {
 
 #[cfg(test)]
 mod tests {
-    use expects::matcher::{consist_of, contain_element, equal};
-    use expects::Subject;
-
     use super::*;
 
     #[test]
@@ -234,7 +231,7 @@ mod tests {
         let tags = repository.all_tags().unwrap();
 
         assert!(tags.len() >= 76);
-        tags.should(contain_element(Tag {
+        assert!(tags.contains(&Tag {
             name: "v1.4.2".to_string(),
             commit_id: "182d0d1ee933de46bf0b5a6ec269bafa77aba9a2".to_string(),
             commit_timestamp: 1_645_905_004,
@@ -245,24 +242,23 @@ mod tests {
     fn it_retrieves_commit_ids_for_each_tag_of_a_repository() {
         let repository = Repository::new("https://github.com/libgit2/libgit2").unwrap();
 
-        let commit_ids_for_tag = repository.commit_ids_for_each_tag().unwrap();
+        let commit_ids_for_each_tag = repository.commit_ids_for_each_tag().unwrap();
 
-        commit_ids_for_tag
-            .get("v1.4.2")
-            .unwrap()
-            .should(consist_of(&[
-                "43bfa124c844288a9e2e361e1122cc1cc51f1e8f".to_string(),
-                "5d9f2aff9423a0395fd909312e2cfd7085552fd8".to_string(),
-                "377ec9bfe7d84aad1ac23206144b7cdb7f867df2".to_string(),
-                "f2c5d1b105d07c3643d1af388715321bdcbd83db".to_string(),
-                "970c3c71cefd764857a57b6d9f04e147ec3114b6".to_string(),
+        assert_eq!(
+            commit_ids_for_each_tag.get("v1.4.2").unwrap(),
+            &[
                 "182d0d1ee933de46bf0b5a6ec269bafa77aba9a2".to_string(),
-            ]));
-        commit_ids_for_tag
-            .get("v1.4.0")
-            .unwrap()
-            .len()
-            .should(equal(302_usize));
+                "970c3c71cefd764857a57b6d9f04e147ec3114b6".to_string(),
+                "f2c5d1b105d07c3643d1af388715321bdcbd83db".to_string(),
+                "377ec9bfe7d84aad1ac23206144b7cdb7f867df2".to_string(),
+                "5d9f2aff9423a0395fd909312e2cfd7085552fd8".to_string(),
+                "43bfa124c844288a9e2e361e1122cc1cc51f1e8f".to_string(),
+            ]
+        );
+        assert_eq!(
+            commit_ids_for_each_tag.get("v1.4.0").unwrap().len(),
+            302_usize
+        );
     }
 
     #[test]
@@ -271,20 +267,17 @@ mod tests {
 
         let commits_for_each_tag = repository.commits_for_each_tag().unwrap();
 
-        commits_for_each_tag
+        assert!(commits_for_each_tag
             .get("v1.4.2")
             .unwrap()
-            .should(contain_element(Commit {
+            .contains(&Commit {
                 id: "43bfa124c844288a9e2e361e1122cc1cc51f1e8f".to_string(),
                 author_name: "Carlos Martín Nieto".to_string(),
                 author_email: "carlosmn@github.com".to_string(),
                 creation_timestamp: 1_645_898_340,
             }));
-        commits_for_each_tag
-            .get("v1.4.2")
-            .unwrap()
-            .len()
-            .should(equal(6_usize));
+
+        assert_eq!(commits_for_each_tag.get("v1.4.2").unwrap().len(), 6_usize);
     }
 
     #[test]
@@ -311,10 +304,10 @@ mod tests {
                 < 1
         );
 
-        commits_for_each_tag
+        assert!(commits_for_each_tag
             .get("v1.4.2")
             .unwrap()
-            .should(contain_element(Commit {
+            .contains(&Commit {
                 id: "43bfa124c844288a9e2e361e1122cc1cc51f1e8f".to_string(),
                 author_name: "Carlos Martín Nieto".to_string(),
                 author_email: "carlosmn@github.com".to_string(),

--- a/src/infra/package_manager/cargo.rs
+++ b/src/infra/package_manager/cargo.rs
@@ -78,9 +78,6 @@ impl crate::pkg::InfoRetriever for InfoRetriever {
 
 #[cfg(test)]
 mod tests {
-    use expects::matcher::equal;
-    use expects::Subject;
-
     use super::*;
     use crate::pkg::InfoRetriever as _;
 
@@ -90,7 +87,7 @@ mod tests {
 
         let result = retriever.latest_version("serde");
 
-        result.unwrap().should(equal("1.0.138"));
+        assert_eq!(result.unwrap(), "1.0.138");
     }
 
     #[test]
@@ -99,9 +96,12 @@ mod tests {
 
         let result = retriever.repository("serde");
 
-        result.unwrap().should(equal(Repository::GitHub {
-            organization: "serde-rs".to_string(),
-            name: "serde".to_string(),
-        }));
+        assert_eq!(
+            result.unwrap(),
+            Repository::GitHub {
+                organization: "serde-rs".into(),
+                name: "serde".into(),
+            }
+        );
     }
 }

--- a/src/infra/package_manager/npm.rs
+++ b/src/infra/package_manager/npm.rs
@@ -61,9 +61,6 @@ impl crate::pkg::InfoRetriever for InfoRetriever {
 
 #[cfg(test)]
 mod tests {
-    use expects::matcher::{be_ok, equal};
-    use expects::Subject;
-
     use super::InfoRetriever;
     use crate::pkg::InfoRetriever as _;
     use crate::pkg::Repository;
@@ -74,7 +71,7 @@ mod tests {
 
         let result = retriever.latest_version("colors");
 
-        result.should(be_ok(equal("1.4.0")));
+        assert_eq!(result.unwrap(), "1.4.0");
     }
 
     #[test]
@@ -83,10 +80,13 @@ mod tests {
 
         let result = retriever.repository("colors");
 
-        result.should(be_ok(equal(Repository::GitHub {
-            organization: "Marak".into(),
-            name: "colors.js".into(),
-        })));
+        assert_eq!(
+            result.unwrap(),
+            Repository::GitHub {
+                organization: "Marak".into(),
+                name: "colors.js".into(),
+            }
+        );
     }
 
     #[test]
@@ -95,10 +95,13 @@ mod tests {
 
         let result = retriever.repository("babel");
 
-        result.should(be_ok(equal(Repository::GitHub {
-            organization: "babel".into(),
-            name: "babel".into(),
-        })));
+        assert_eq!(
+            result.unwrap(),
+            Repository::GitHub {
+                organization: "babel".into(),
+                name: "babel".into(),
+            }
+        );
     }
 
     #[test]
@@ -107,10 +110,13 @@ mod tests {
 
         let result = retriever.repository("bfj");
 
-        result.should(be_ok(equal(Repository::GitLab {
-            organization: "philbooth".into(),
-            name: "bfj".into(),
-        })));
+        assert_eq!(
+            result.unwrap(),
+            Repository::GitLab {
+                organization: "philbooth".into(),
+                name: "bfj".into(),
+            }
+        );
     }
 
     #[test]
@@ -119,9 +125,12 @@ mod tests {
 
         let result = retriever.repository("atob");
 
-        result.should(be_ok(equal(Repository::Raw {
-            address: "git://git.coolaj86.com/coolaj86/atob.js.git".into(),
-        })));
+        assert_eq!(
+            result.unwrap(),
+            Repository::Raw {
+                address: "git://git.coolaj86.com/coolaj86/atob.js.git".into(),
+            }
+        );
     }
 
     #[test]
@@ -130,6 +139,6 @@ mod tests {
 
         let result = retriever.repository("@types/json5");
 
-        result.should(be_ok(equal(Repository::Unknown)));
+        assert_eq!(result.unwrap(), Repository::Unknown);
     }
 }

--- a/src/pkg/config/mod.rs
+++ b/src/pkg/config/mod.rs
@@ -97,68 +97,76 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-    use expects::matcher::equal;
-    use expects::Subject;
-
     use super::*;
 
     #[test]
     fn it_loads_the_default_config_from_an_empty_file() {
         let config: Config = Config::load_from_reader(&mut "".as_bytes()).unwrap_or_default();
-        config.should(equal(Config {
-            default_policies: Policies {
-                contributors_ratio: Some(contributors_ratio::Config {
-                    max_number_of_releases_to_check: 3_usize,
-                    max_contributor_ratio: 0.5,
-                }),
-                min_number_of_releases_required: Some(min_number_of_releases_required::Config {
-                    min_number_of_releases: 3_usize,
-                    days: 365_u64,
-                }),
-                max_issue_lifespan: Some(max_issue_lifespan::Config {
-                    max_lifespan_in_seconds: 2_592_000_usize,
-                    last_issues: 300,
-                }),
-                max_pull_request_lifespan: Some(max_pull_request_lifespan::Config {
-                    max_lifespan_in_seconds: 2_592_000_usize,
-                    last_pull_requests: 300,
-                }),
-            },
-            dependency_config: vec![],
-        }));
+        assert_eq!(
+            config,
+            Config {
+                default_policies: Policies {
+                    contributors_ratio: Some(contributors_ratio::Config {
+                        max_number_of_releases_to_check: 3_usize,
+                        max_contributor_ratio: 0.5,
+                    }),
+                    min_number_of_releases_required: Some(
+                        min_number_of_releases_required::Config {
+                            min_number_of_releases: 3_usize,
+                            days: 365_u64,
+                        }
+                    ),
+                    max_issue_lifespan: Some(max_issue_lifespan::Config {
+                        max_lifespan_in_seconds: 2_592_000_usize,
+                        last_issues: 300,
+                    }),
+                    max_pull_request_lifespan: Some(max_pull_request_lifespan::Config {
+                        max_lifespan_in_seconds: 2_592_000_usize,
+                        last_pull_requests: 300,
+                    }),
+                },
+                dependency_config: vec![],
+            }
+        );
     }
 
     #[test]
     fn it_loads_the_config_from_reader() {
         let config: Config = Config::load_from_reader(&mut config_example()).unwrap();
-        config.should(equal(Config {
-            default_policies: Policies {
-                contributors_ratio: Some(contributors_ratio::Config {
-                    max_number_of_releases_to_check: 3_usize,
-                    max_contributor_ratio: 0.8,
-                }),
-                min_number_of_releases_required: Some(min_number_of_releases_required::Config {
-                    min_number_of_releases: 3_usize,
-                    days: 180_u64,
-                }),
-                max_issue_lifespan: Some(max_issue_lifespan::Config {
-                    max_lifespan_in_seconds: 2_592_000_usize,
-                    last_issues: 300,
-                }),
-                max_pull_request_lifespan: Some(max_pull_request_lifespan::Config {
-                    max_lifespan_in_seconds: 2_592_000_usize,
-                    last_pull_requests: 300,
-                }),
-            },
-            dependency_config: vec![],
-        }));
+        assert_eq!(
+            config,
+            Config {
+                default_policies: Policies {
+                    contributors_ratio: Some(contributors_ratio::Config {
+                        max_number_of_releases_to_check: 3_usize,
+                        max_contributor_ratio: 0.8,
+                    }),
+                    min_number_of_releases_required: Some(
+                        min_number_of_releases_required::Config {
+                            min_number_of_releases: 3_usize,
+                            days: 180_u64,
+                        }
+                    ),
+                    max_issue_lifespan: Some(max_issue_lifespan::Config {
+                        max_lifespan_in_seconds: 2_592_000_usize,
+                        last_issues: 300,
+                    }),
+                    max_pull_request_lifespan: Some(max_pull_request_lifespan::Config {
+                        max_lifespan_in_seconds: 2_592_000_usize,
+                        last_pull_requests: 300,
+                    }),
+                },
+                dependency_config: vec![],
+            }
+        );
     }
 
     #[test]
     fn it_dumps_the_config_to_string() {
         let config: Config = Config::default();
         let config_string = config.dump_to_string().unwrap();
-        config_string.should(equal(
+        assert_eq!(
+            config_string,
             "\
 ---
 default_policies:
@@ -175,76 +183,82 @@ default_policies:
     max_lifespan_in_seconds: 2592000
     last_pull_requests: 300
 dependency_config: []
-",
-        ));
+"
+        );
     }
 
     #[test]
     fn it_loads_the_config_with_a_missing_policy() {
         let config: Config =
             Config::load_from_reader(&mut config_example_with_missing_policy()).unwrap();
-        config.should(equal(Config {
-            default_policies: Policies {
-                contributors_ratio: Some(contributors_ratio::Config {
-                    max_number_of_releases_to_check: 3_usize,
-                    max_contributor_ratio: 0.5,
-                }),
-                min_number_of_releases_required: None,
-                max_issue_lifespan: None,
-                max_pull_request_lifespan: None,
-            },
-            dependency_config: vec![],
-        }));
+        assert_eq!(
+            config,
+            Config {
+                default_policies: Policies {
+                    contributors_ratio: Some(contributors_ratio::Config {
+                        max_number_of_releases_to_check: 3_usize,
+                        max_contributor_ratio: 0.5,
+                    }),
+                    min_number_of_releases_required: None,
+                    max_issue_lifespan: None,
+                    max_pull_request_lifespan: None,
+                },
+                dependency_config: vec![],
+            }
+        );
     }
 
     #[test]
     fn it_loads_the_config_for_a_specific_policy() {
         let config = Config::load_from_reader(&mut config_example_for_specific_policy()).unwrap();
-        config.should(equal(Config {
-            default_policies: Policies {
-                contributors_ratio: None,
-                min_number_of_releases_required: None,
-                max_issue_lifespan: None,
-                max_pull_request_lifespan: None,
-            },
-            dependency_config: vec![
-                DependencyConfiguration {
-                    name: "foo".to_string(),
-                    policies: Policies {
-                        contributors_ratio: Some(contributors_ratio::Config {
-                            max_number_of_releases_to_check: 3_usize,
-                            max_contributor_ratio: 0.8,
-                        }),
-                        min_number_of_releases_required: Some(
-                            min_number_of_releases_required::Config {
-                                min_number_of_releases: 3_usize,
-                                days: 180_u64,
-                            },
-                        ),
-                        max_issue_lifespan: Some(max_issue_lifespan::Config {
-                            max_lifespan_in_seconds: 2_592_000_usize,
-                            last_issues: 300,
-                        }),
-                        max_pull_request_lifespan: Some(max_pull_request_lifespan::Config {
-                            max_lifespan_in_seconds: 2_592_000_usize,
-                            last_pull_requests: 300,
-                        }),
-                    },
+        assert_eq!(
+            config,
+            Config {
+                default_policies: Policies {
+                    contributors_ratio: None,
+                    min_number_of_releases_required: None,
+                    max_issue_lifespan: None,
+                    max_pull_request_lifespan: None,
                 },
-                DependencyConfiguration {
-                    name: "bar".to_string(),
-                    policies: Policies {
-                        contributors_ratio: Some(contributors_ratio::Config {
-                            max_number_of_releases_to_check: 5_usize,
-                            max_contributor_ratio: 0.5,
-                        }),
-                        min_number_of_releases_required: None,
-                        max_issue_lifespan: None,
-                        max_pull_request_lifespan: None,
+                dependency_config: vec![
+                    DependencyConfiguration {
+                        name: "foo".to_string(),
+                        policies: Policies {
+                            contributors_ratio: Some(contributors_ratio::Config {
+                                max_number_of_releases_to_check: 3_usize,
+                                max_contributor_ratio: 0.8,
+                            }),
+                            min_number_of_releases_required: Some(
+                                min_number_of_releases_required::Config {
+                                    min_number_of_releases: 3_usize,
+                                    days: 180_u64,
+                                },
+                            ),
+                            max_issue_lifespan: Some(max_issue_lifespan::Config {
+                                max_lifespan_in_seconds: 2_592_000_usize,
+                                last_issues: 300,
+                            }),
+                            max_pull_request_lifespan: Some(max_pull_request_lifespan::Config {
+                                max_lifespan_in_seconds: 2_592_000_usize,
+                                last_pull_requests: 300,
+                            }),
+                        },
                     },
-                },
-            ],
-        }));
+                    DependencyConfiguration {
+                        name: "bar".to_string(),
+                        policies: Policies {
+                            contributors_ratio: Some(contributors_ratio::Config {
+                                max_number_of_releases_to_check: 5_usize,
+                                max_contributor_ratio: 0.5,
+                            }),
+                            min_number_of_releases_required: None,
+                            max_issue_lifespan: None,
+                            max_pull_request_lifespan: None,
+                        },
+                    },
+                ],
+            }
+        );
     }
 
     fn config_example_for_specific_policy() -> &'static [u8] {

--- a/src/pkg/engine.rs
+++ b/src/pkg/engine.rs
@@ -72,10 +72,6 @@ impl PolicyExecutor {
 
 #[cfg(test)]
 mod tests {
-
-    use expects::matcher::consist_of;
-    use expects::Subject;
-
     use super::*;
     use crate::pkg::policy::MockPolicy;
     use crate::pkg::Repository;
@@ -110,10 +106,13 @@ mod tests {
 
         let evaluation = policy_executor.evaluate(&dependency()).unwrap();
 
-        evaluation.should(consist_of(&[
-            Evaluation::Pass("some_policy_name".to_string(), dependency()),
-            Evaluation::Pass("some_policy_name2".to_string(), dependency()),
-        ]));
+        assert_eq!(
+            evaluation,
+            &[
+                Evaluation::Pass("some_policy_name".to_string(), dependency()),
+                Evaluation::Pass("some_policy_name2".to_string(), dependency()),
+            ]
+        );
     }
 
     #[test]
@@ -193,10 +192,13 @@ mod tests {
 
         let evaluation = policy_executor.evaluate(&dependency()).unwrap();
 
-        evaluation.should(consist_of(&[Evaluation::Pass(
-            "some_policy_name2".to_string(),
-            dependency(),
-        )]));
+        assert_eq!(
+            evaluation,
+            &[Evaluation::Pass(
+                "some_policy_name2".to_string(),
+                dependency()
+            )]
+        );
     }
 
     #[test]
@@ -262,10 +264,13 @@ mod tests {
 
         let evaluation = policy_executor.evaluate(&dependency()).unwrap();
 
-        evaluation.should(consist_of(&[Evaluation::Pass(
-            "some_policy_name2".to_string(),
-            dependency(),
-        )]));
+        assert_eq!(
+            evaluation,
+            &[Evaluation::Pass(
+                "some_policy_name2".to_string(),
+                dependency()
+            )]
+        );
     }
 
     fn dependency() -> Dependency {

--- a/src/pkg/package_manager/cargo.rs
+++ b/src/pkg/package_manager/cargo.rs
@@ -99,8 +99,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use expects::matcher::equal;
-    use expects::Subject;
     use mockall::predicate::eq;
 
     use super::*;
@@ -132,15 +130,18 @@ mod tests {
         let dependency_reader = DependencyReader::new(cargo_lock_file_contents(), retriever);
         let mut dependencies = dependency_reader.dependencies().unwrap();
 
-        dependencies.next().unwrap().should(equal(Dependency {
-            name: "serde".into(),
-            version: "1.0.137".into(),
-            latest_version: Some("1.0.138".into()),
-            repository: Repository::GitHub {
-                organization: "serde-rs".into(),
+        assert_eq!(
+            dependencies.next().unwrap(),
+            Dependency {
                 name: "serde".into(),
-            },
-        }));
+                version: "1.0.137".into(),
+                latest_version: Some("1.0.138".into()),
+                repository: Repository::GitHub {
+                    organization: "serde-rs".into(),
+                    name: "serde".into(),
+                },
+            }
+        );
     }
 
     fn cargo_lock_file_contents() -> &'static [u8] {

--- a/src/pkg/package_manager/npm.rs
+++ b/src/pkg/package_manager/npm.rs
@@ -77,8 +77,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use expects::matcher::equal;
-    use expects::Subject;
     use mockall::predicate::eq;
 
     use super::*;
@@ -109,11 +107,9 @@ mod tests {
         let dependency_reader = DependencyReader::new(npm_package_lock(), retriever);
         let dependencies = dependency_reader.dependencies();
 
-        dependencies
-            .unwrap()
-            .next()
-            .unwrap()
-            .should(equal(Dependency {
+        assert_eq!(
+            dependencies.unwrap().next().unwrap(),
+            Dependency {
                 name: "colors".into(),
                 version: "1.4.0".into(),
                 latest_version: Some("1.4.1".into()),
@@ -121,7 +117,8 @@ mod tests {
                     organization: "org".into(),
                     name: "name".into(),
                 },
-            }));
+            }
+        );
     }
 
     fn npm_package_lock() -> &'static [u8] {

--- a/src/pkg/policy/contributors_ratio.rs
+++ b/src/pkg/policy/contributors_ratio.rs
@@ -100,8 +100,6 @@ impl ContributorsRatio {
 mod tests {
     use std::collections::HashMap;
 
-    use expects::matcher::{be_ok, equal};
-    use expects::Subject;
     use mockall::predicate::eq;
 
     use super::super::{Commit, MockCommitRetriever, Tag};
@@ -170,10 +168,10 @@ mod tests {
         };
         let result = contributors_ratio_policy.evaluate(&dependency);
 
-        result.should(be_ok(equal(Evaluation::Pass(
-            "contributors_ratio".to_string(),
-            dependency,
-        ))));
+        assert_eq!(
+            result.unwrap(),
+            Evaluation::Pass("contributors_ratio".to_string(), dependency.clone())
+        );
     }
     #[test]
     fn if_the_contributor_ratio_for_the_latest_release_is_higher_than_90_percent_it_should_fail() {
@@ -232,12 +230,12 @@ mod tests {
 
         match result.unwrap() {
             Evaluation::Fail(policy, dep, reason, score) => {
-                policy.should(equal("contributors_ratio".to_string()));
-                dep.should(equal(dependency));
-                reason.should(equal(
+                assert_eq!(policy, "contributors_ratio");
+                assert_eq!(dep, dependency);
+                assert_eq!(
+                    reason,
                     "the rate of contribution is too high (1 > 0.9) for author SomeAuthor"
-                        .to_owned(),
-                ));
+                );
                 println!("{}", score);
                 assert!((score - 1.111_111_111_111_111_2).abs() < f64::EPSILON);
             }

--- a/src/pkg/policy/max_issue_lifespan.rs
+++ b/src/pkg/policy/max_issue_lifespan.rs
@@ -48,9 +48,6 @@ impl MaxIssueLifespan {
 
 #[cfg(test)]
 mod tests {
-    use expects::matcher::equal;
-    use expects::Subject;
-
     use super::super::{ContributionDataRetriever, MockContributionDataRetriever, Policy};
     use super::*;
     use crate::pkg::Repository::GitHub;
@@ -70,10 +67,10 @@ mod tests {
         let issue_lifespan = MaxIssueLifespan::new(retriever, max_allowed_issue_lifespan, 100);
 
         let evaluation = issue_lifespan.evaluate(&dependency());
-        evaluation.unwrap().should(equal(Evaluation::Pass(
-            "max_issue_lifespan".to_string(),
-            dependency(),
-        )));
+        assert_eq!(
+            evaluation.unwrap(),
+            Evaluation::Pass("max_issue_lifespan".to_string(), dependency(),)
+        );
     }
 
     #[test]
@@ -92,9 +89,9 @@ mod tests {
         let evaluation = issue_lifespan.evaluate(&dependency());
         match evaluation.unwrap() {
             Evaluation::Fail(policy, dep, reason, score) => {
-                policy.should(equal("max_issue_lifespan".to_string()));
-                dep.should(equal(dependency()));
-                reason.should(equal("the issue lifespan is 102 seconds, which is greater than the maximum allowed lifespan of 100 seconds"));
+                assert_eq!(policy, "max_issue_lifespan");
+                assert_eq!(dep, dependency());
+                assert_eq!(reason, "the issue lifespan is 102 seconds, which is greater than the maximum allowed lifespan of 100 seconds");
                 assert!((score - 1.02).abs() < f64::EPSILON);
             }
             Evaluation::Pass(_, _) => {

--- a/src/pkg/policy/max_pull_request_lifespan.rs
+++ b/src/pkg/policy/max_pull_request_lifespan.rs
@@ -52,8 +52,6 @@ impl MaxPullRequestLifespan {
 
 #[cfg(test)]
 mod tests {
-    use expects::matcher::equal;
-    use expects::Subject;
 
     use super::super::{ContributionDataRetriever, MockContributionDataRetriever, Policy};
     use super::*;
@@ -75,10 +73,10 @@ mod tests {
             MaxPullRequestLifespan::new(retriever, max_allowed_issue_lifespan, 100);
 
         let evaluation = issue_lifespan.evaluate(&dependency());
-        evaluation.unwrap().should(equal(Evaluation::Pass(
-            "max_pull_request_lifespan".to_string(),
-            dependency(),
-        )));
+        assert_eq!(
+            evaluation.unwrap(),
+            Evaluation::Pass("max_pull_request_lifespan".to_string(), dependency())
+        );
     }
 
     #[test]
@@ -98,9 +96,12 @@ mod tests {
         let evaluation = issue_lifespan.evaluate(&dependency());
         match evaluation.unwrap() {
             Evaluation::Fail(policy, dep, reason, score) => {
-                policy.should(equal("max_pull_request_lifespan".to_string()));
-                dep.should(equal(dependency()));
-                reason.should(equal("the pull request lifespan is 102 seconds, which is greater than the maximum allowed lifespan of 100 seconds"));
+                assert_eq!(policy, "max_pull_request_lifespan".to_string());
+                assert_eq!(dep, dependency());
+                assert_eq!(
+                    reason,
+                    format!("the pull request lifespan is 102 seconds, which is greater than the maximum allowed lifespan of 100 seconds")
+                );
                 assert!((score - 1.02).abs() < f64::EPSILON);
             }
             Evaluation::Pass(_, _) => {

--- a/src/pkg/policy/min_number_of_releases_required.rs
+++ b/src/pkg/policy/min_number_of_releases_required.rs
@@ -78,8 +78,6 @@ impl MinNumberOfReleasesRequired {
 mod tests {
     use std::time::Duration;
 
-    use expects::matcher::{be_ok, equal};
-    use expects::Subject;
     use mockall::predicate::eq;
 
     use super::super::{MockClock, MockCommitRetriever, Tag};
@@ -137,10 +135,10 @@ mod tests {
         let result: Result<Evaluation, Box<dyn Error>> =
             number_of_releases_policy.evaluate(&dependency);
 
-        result.should(be_ok(equal(Evaluation::Pass(
-            "min_number_of_releases_required".to_string(),
-            dependency,
-        ))));
+        assert_eq!(
+            result.unwrap(),
+            Evaluation::Pass("min_number_of_releases_required".to_string(), dependency)
+        );
     }
 
     #[test]
@@ -179,12 +177,15 @@ mod tests {
         let result: Result<Evaluation, Box<dyn Error>> =
             number_of_releases_policy.evaluate(&dependency);
 
-        result.should(be_ok(equal(Evaluation::Fail(
-            "min_number_of_releases_required".to_string(),
-            dependency,
-            "expected 2 releases in the last 1260 days, but found 1".to_string(),
-            0.5,
-        ))));
+        assert_eq!(
+            result.unwrap(),
+            Evaluation::Fail(
+                "min_number_of_releases_required".to_string(),
+                dependency,
+                "expected 2 releases in the last 1260 days, but found 1".to_string(),
+                0.5,
+            )
+        );
     }
 
     #[test]
@@ -236,11 +237,14 @@ mod tests {
         let result: Result<Evaluation, Box<dyn Error>> =
             number_of_releases_policy.evaluate(&dependency);
 
-        result.should(be_ok(equal(Evaluation::Fail(
-            "min_number_of_releases_required".to_string(),
-            dependency,
-            "expected 2 releases in the last 1260 days, but found 0".to_string(),
-            1.0,
-        ))));
+        assert_eq!(
+            result.unwrap(),
+            Evaluation::Fail(
+                "min_number_of_releases_required".to_string(),
+                dependency,
+                "expected 2 releases in the last 1260 days, but found 0".to_string(),
+                1.0,
+            )
+        );
     }
 }

--- a/src/pkg/recognizer.rs
+++ b/src/pkg/recognizer.rs
@@ -22,49 +22,58 @@ impl PackageManager {
 
 #[cfg(test)]
 mod tests {
-    use expects::{
-        matcher::{be_none, be_some, equal},
-        Subject,
-    };
-
     use super::*;
 
     #[test]
     fn it_recognizes_the_npm_package_lock_file() {
-        PackageManager::from_filename("package-lock.json")
-            .should(be_some(equal(PackageManager::Npm)));
+        assert_eq!(
+            PackageManager::from_filename("package-lock.json").unwrap(),
+            PackageManager::Npm
+        );
     }
 
     #[test]
     fn it_recognizes_the_npm_package_lock_file_even_with_full_path() {
-        PackageManager::from_filename("/path/to/package-lock.json")
-            .should(be_some(equal(PackageManager::Npm)));
+        assert_eq!(
+            PackageManager::from_filename("/path/to/package-lock.json").unwrap(),
+            PackageManager::Npm
+        );
     }
 
     #[test]
     fn it_recognizes_the_cargo_package_lock_file() {
-        PackageManager::from_filename("Cargo.lock").should(be_some(equal(PackageManager::Cargo)));
+        assert_eq!(
+            PackageManager::from_filename("Cargo.lock").unwrap(),
+            PackageManager::Cargo
+        );
     }
 
     #[test]
     fn it_recognizes_the_cargo_package_lock_file_even_with_full_path() {
-        PackageManager::from_filename("/path/to/Cargo.lock")
-            .should(be_some(equal(PackageManager::Cargo)));
+        assert_eq!(
+            PackageManager::from_filename("/path/to/Cargo.lock").unwrap(),
+            PackageManager::Cargo
+        );
     }
 
     #[test]
     fn it_recognizes_the_yarn_package_lock_file() {
-        PackageManager::from_filename("yarn.lock").should(be_some(equal(PackageManager::Yarn)));
+        assert_eq!(
+            PackageManager::from_filename("yarn.lock").unwrap(),
+            PackageManager::Yarn
+        );
     }
 
     #[test]
     fn it_recognizes_the_yarn_package_lock_file_even_with_full_path() {
-        PackageManager::from_filename("/path/to/yarn.lock")
-            .should(be_some(equal(PackageManager::Yarn)));
+        assert_eq!(
+            PackageManager::from_filename("/path/to/yarn.lock").unwrap(),
+            PackageManager::Yarn
+        );
     }
 
     #[test]
     fn if_it_doesnt_recognize_the_package_manager_returns_none() {
-        PackageManager::from_filename("some-file-name").should(be_none());
+        assert!(PackageManager::from_filename("some-file-name").is_none());
     }
 }


### PR DESCRIPTION
I started creating a testing dependency (https://github.com/tembleking/expects) to learn while developing this project, but I am not going to maintain it anymore, so I am removing it from here and I've replaced every usage with the standard `assert!` and `assert_eq!` macros.