### PR TITLE
ci: Change test from serde to yaml-rust

### DIFF
--- a/src/infra/package_manager/cargo.rs
+++ b/src/infra/package_manager/cargo.rs
@@ -82,12 +82,12 @@ mod tests {
     use crate::pkg::InfoRetriever as _;
 
     #[test]
-    fn it_retrieves_the_latest_version_of_serde() {
+    fn it_retrieves_the_latest_version_of_yaml_rust() {
         let retriever = InfoRetriever::default();
 
-        let result = retriever.latest_version("serde");
+        let result = retriever.latest_version("yaml-rust");
 
-        assert_eq!(result.unwrap(), "1.0.142");
+        assert_eq!(result.unwrap(), "0.4.5");
     }
 
     #[test]


### PR DESCRIPTION
This changes the test that retrieves the latest version of `serde`, to retrieve the latest one from `yaml-rust`, which changes less often and so we don't need to update it all the time.