### PR TITLE
ci: Update dean PR lifespan in tests

### DIFF
--- a/src/infra/repo_contribution.rs
+++ b/src/infra/repo_contribution.rs
@@ -172,9 +172,9 @@ mod tests {
             .unwrap();
 
         let two_minutes_in_seconds = 2.0 * 60.0;
-        let two_hours_in_seconds = 2.0 * 60.0 * 60.0;
+        let one_day_in_seconds = 1.0 * 24.0 * 60.0 * 60.0;
         assert!(pr_lifespan > two_minutes_in_seconds);
-        assert!(pr_lifespan < two_hours_in_seconds);
+        assert!(pr_lifespan < one_day_in_seconds);
     }
 
     fn mock_issue_store() -> Box<dyn IssueStore> {


### PR DESCRIPTION
The lifespan has increased and this test is failing. This fixes it.